### PR TITLE
Update deprecated method usage

### DIFF
--- a/watcher_fsevents_cgo.go
+++ b/watcher_fsevents_cgo.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+//go:build darwin && !kqueue && cgo
 // +build darwin,!kqueue,cgo
 
 package notify
@@ -106,7 +107,7 @@ func gostream(_, info uintptr, n C.size_t, paths, flags, ids uintptr) {
 				ID:    *(*uint64)(unsafe.Pointer(ids + i*offid)),
 			})
 		}
-
+		
 	}
 	fn(ev)
 }
@@ -173,7 +174,7 @@ func (s *stream) Start() error {
 	if ref == nilstream {
 		return errCreate
 	}
-	C.FSEventStreamScheduleWithRunLoop(ref, runloop, C.kCFRunLoopDefaultMode)
+	C.FSEventStreamSetDispatchQueue(ref, C.dispatch_get_main_queue())
 	if C.FSEventStreamStart(ref) == C.Boolean(0) {
 		C.FSEventStreamInvalidate(ref)
 		return errStart


### PR DESCRIPTION
To quiet warnings like 

```
cgo-gcc-prolog:219:2: warning: 'FSEventStreamScheduleWithRunLoop' is deprecated: first deprecated in macOS 13.0 - Use FSEventStreamSetDispatchQueue instead. [-Wdeprecated-declarations]

/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/FSEvents.framework/Headers/FSEvents.h:1154:1: note: 'FSEventStreamScheduleWithRunLoop' has been explicitly marked deprecated here
```